### PR TITLE
Stretch support

### DIFF
--- a/conf/systemd.service
+++ b/conf/systemd.service
@@ -1,7 +1,7 @@
 [Unit]
 Description=Wekan, task board
-Wants=mongod.service
-After=network.target mongod.service
+Wants=mongodb.service
+After=network.target mongodb.service
 
 [Service]
 Type=simple

--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
     "name": "Wekan",
     "id": "wekan",
     "packaging_format": 1,
-    "version": "1.07~ynh1",
+    "version": "1.07~ynh2",
     "description": {
         "en": "Trello-like kanban",
         "fr": "Un kanban similaire à Trello"
@@ -15,7 +15,7 @@
         "url": "https://github.com/alexAubin/"
     },
     "requirements": {
-        "yunohost": ">= 2.7.2"
+        "yunohost": ">= 3.0.0"
     },
     "multi_instance": true,
     "services": [

--- a/scripts/_future.sh
+++ b/scripts/_future.sh
@@ -160,6 +160,7 @@ ynh_remove_nodejs () {
         ynh_secure_remove "$n_install_dir"
         ynh_secure_remove "/usr/local/n"
         sed --in-place "/N_PREFIX/d" /root/.bashrc
+	rm -f /etc/cron.daily/node_update
     fi
 }
 

--- a/scripts/_future.sh
+++ b/scripts/_future.sh
@@ -210,4 +210,4 @@ EOF
     chmod +x "/etc/cron.daily/node_update"
 }
 
-ynh_version_gt() { test "$(printf '%s\n' "$@" | sort -V | head -n 1)" != "$1"; }
+ynh_version_gt() { dpkg --compare-versions "$1" gt "$2" }

--- a/scripts/install
+++ b/scripts/install
@@ -50,12 +50,7 @@ ynh_app_setting_set $app port $port
 #=================================================
 ynh_install_nodejs 8.9.3
 
-# Install mongodb
-wget https://www.mongodb.org/static/pgp/server-3.2.asc -O - | apt-key add -
-echo "deb http://repo.mongodb.org/apt/debian jessie/mongodb-org/3.2 main" | sudo tee /etc/apt/sources.list.d/mongodb-org-3.2.list
-
-ynh_install_app_dependencies "mongodb-org mongodb-org-server mongodb-org-shell mongodb-org-mongos mongodb-org-tools"
-   
+ynh_install_app_dependencies "mongodb mongodb-server"
 
 #=================================================
 # DOWNLOAD, CHECK AND UNPACK SOURCE
@@ -89,8 +84,8 @@ npm install
 popd
 
 # Start mogodb
-systemctl enable mongod
-systemctl restart mongod
+systemctl enable mongodb
+systemctl restart mongodb
 
 #=================================================
 # SETUP SYSTEMD
@@ -117,7 +112,7 @@ find "$final_path" -type d -print0 | xargs -0 chmod 750
 #=================================================
 # ADD SERVICE IN ADMIN PANEL
 #=================================================
-yunohost service add mongod --log "/var/log/mongodb.log"
+yunohost service add mongodb --log "/var/log/mongodb/mongodb.log"
 yunohost service add $app
 
 #=================================================

--- a/scripts/remove
+++ b/scripts/remove
@@ -49,22 +49,11 @@ ynh_remove_app_dependencies
 
 ynh_remove_nodejs
 
-
-#=================================================
-# REMOVE MONGODB
-#=================================================
-# TODO / FIXME : remove the keys added ?
-#apt-key del EA312927
-#apt-key del 0C49F3730359A14518585931BC711F9BA15703C6
-        
-#rm -f /etc/apt/sources.list.d/mongodb-org-3.2.list
-
 #=================================================
 # REMOVE THE MAIN DIR OF THE APP
 #=================================================
 
 ynh_secure_remove "/var/www/$app"
-
 
 #=================================================
 # REMOVE THE NGINX CONFIGURATION

--- a/scripts/restore
+++ b/scripts/restore
@@ -55,17 +55,14 @@ ynh_system_user_create $app "$final_path"
 ynh_install_nodejs 4.8.7
 
 # Install mongodb
-wget https://www.mongodb.org/static/pgp/server-3.2.asc -O - | apt-key add -
-echo "deb http://repo.mongodb.org/apt/ubuntu xenial/mongodb-org/3.2 multiverse" > /etc/apt/sources.list.d/mongodb-org-3.2.list
-
-ynh_install_app_dependencies "mongodb-org mongodb-org-server mongodb-org-shell mongodb-org-mongos mongodb-org-tools"
+ynh_install_app_dependencies "mongodb mongodb-server"
 
 #=================================================
 # RESTORE DB
 #=================================================
 # Start mogodb
-systemctl enable mongod
-systemctl start mongod
+systemctl enable mongodb
+systemctl start mongodb
 mongorestore --db $app ./dump
 
 #=================================================
@@ -92,7 +89,7 @@ find "$final_path" -type d -print0 | xargs -0 chmod 750
 #=================================================
 # ADD SERVICE IN ADMIN PANEL
 #=================================================
-yunohost service add mongod --log "/var/log/mongodb.log"
+yunohost service add mongodb --log "/var/log/mongodb/mongodb.log"
 yunohost service add $app
 
 #=================================================

--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -25,6 +25,8 @@ port=$(ynh_app_setting_get $app port)
 # Check version
 #=================================================
 abort_if_up_to_date
+# previous function is what defines 'version', more precisely the 'previous version'
+previous_version="${version}"
 
 #=================================================
 # BACKUP BEFORE UPGRADE THEN ACTIVE TRAP
@@ -40,25 +42,14 @@ ynh_abort_if_errors	# Exit if an error occurs during the execution of the script
 # ENSURE DOWNWARD COMPATIBILITY
 #=================================================
 
-if ynh_version_gt "0.45-2" "${version}" ; then
+if ynh_version_gt "0.45-2" "${previous_version}" ; then
     ynh_replace_string "Environment=ROOT_URL=http://127.0.0.1:$port$path_url" "Environment=ROOT_URL=https://$domain$path_url/" "/etc/systemd/system/$app.service"
     systemctl daemon-reload
 fi
-if ynh_version_gt "0.45-3" "${version}" ; then
+if ynh_version_gt "0.45-3" "${previous_version}" ; then
     yunohost service add $app
 fi
-if ynh_version_gt "0.54-2" "${version}" ; then
-    systemctl enable mongod
-    systemctl restart mongod
-fi
-if ynh_version_gt "0.54-3" "${version}" ; then
-    apt-key del EA312927
-    wget https://www.mongodb.org/static/pgp/server-3.2.asc -O - | apt-key add -
-fi
-if ynh_version_gt "0.63-1" "${version}" ; then
-    ynh_install_nodejs 4.8.7
-fi
-if ynh_version_gt "0.77-2" "${version}" ; then
+if ynh_version_gt "0.77-2" "${previous_version}" ; then
     ynh_install_nodejs 8.9.3
     # Create a dedicated systemd config
     ynh_replace_string "__NODEJS__"   "$nodejs_use_version" "../conf/systemd.service"
@@ -68,6 +59,27 @@ if ynh_version_gt "0.77-2" "${version}" ; then
     ynh_replace_string "__PORT__"     "$port"               "../conf/systemd.service"
     ynh_replace_string "__DOMAIN__"   "$domain"             "../conf/systemd.service"
     ynh_add_systemd_config
+fi
+if ynh_version_gt "1.07~ynh2" "${previous_version}" ; then
+
+   # Replace mongodb packages
+   # Assume no other app needs it >.>
+   rm -f /etc/apt/sources.list.d/mongodb-org-3.2.list
+   ynh_remove_app_dependencies
+   ynh_install_app_dependencies "mongodb mongodb-server"
+   yunohost service remove mongod
+   yunohost service add mongodb --log "/var/log/mongodb/mongodb.log"
+
+   # Gotta regen the systemd config because mongodb service name changed
+   nodejs_version=$(ynh_app_setting_get $app nodejs_version)
+   nodejs_use_version="$n_install_dir/bin/n -q $nodejs_version"
+   ynh_replace_string "__NODEJS__"   "$nodejs_use_version" "../conf/systemd.service"
+   ynh_replace_string "__ENV_PATH__" "$PATH"               "../conf/systemd.service"
+   ynh_replace_string "__DB_NAME__"  "$app"                "../conf/systemd.service"
+   ynh_replace_string "__URI__"      "$path_url/"          "../conf/systemd.service"
+   ynh_replace_string "__PORT__"     "$port"               "../conf/systemd.service"
+   ynh_replace_string "__DOMAIN__"   "$domain"             "../conf/systemd.service"
+   ynh_add_systemd_config
 fi
 
 


### PR DESCRIPTION
(This PR fixes #20 and #14 and #6.)

So that's a yolo attempt to make it work on Stretch.

I havent really tested anything except for the install part. The upgrade is a bit touchy.

The proposal is to rely on mongodb 3.2 packages provided by debian in stretch : https://packages.debian.org/stretch/mongodb

To make things more spicy, mongodb people decided it would be fun to rename the service from `mongod` to `mongodb`, so all scripts+systemd conf have to be updated...

Tests and feedback are really welcome !