### PR TITLE
Check that architecture is supported

### DIFF
--- a/scripts/install
+++ b/scripts/install
@@ -26,6 +26,10 @@ app=$YNH_APP_INSTANCE_NAME
 #=================================================
 # CHECK IF THE APP CAN BE INSTALLED WITH THESE ARGS
 #=================================================
+
+# Check machine architecture (in particular, we don't support ARM and 32bit machines)
+[[ $(uname -m) == "x86_64" ]] || ynh_die "Sorry, but this app can only be installed on a x86, 64 bits machine :("
+
 final_path=/var/www/$app
 test ! -e "$final_path" || ynh_die "This path already contains a folder"
 


### PR DESCRIPTION
Install is not expected to work on non-x86_64 machines so we should check this as soon as we can and abort the installation if the architecture is not supported.