### PR TITLE
[enh] Upgrade to wekan v2.56

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ If you don't have YunoHost, please see [here](https://yunohost.org/#/install) to
 ## Overview
 Wekan is an open-source kanban board (task manager and organizer)
 
-**Shipped version:** 2.48
+**Shipped version:** 2.56
 
 ## Screenshots
 

--- a/check_process
+++ b/check_process
@@ -32,5 +32,5 @@
 	Level 9=0
 	Level 10=0
 ;;; Options
-Email=ljf+ynh-wekan@grimaud.me
+Email=ljf+ynh-wekan@reflexlibre.net
 Notification=down

--- a/conf/app.src
+++ b/conf/app.src
@@ -1,8 +1,8 @@
 # This is on YunoHost server just to avoid the file from disappearing
 # Original source is https://releases.wekan.team/
-SOURCE_URL=https://github.com/yalh76/wekan_ynh/releases/download/v2.48/wekan-2.48.tar.gz
-SOURCE_SUM=1d6ae104487cb29029e6187531432a9c3dd2d9c4e1aef4f848ae48286010b0e8
+SOURCE_URL=https://build.yunohost.org/apps/wekan-2.56.tar.gz
+SOURCE_SUM=bf4c8a6d958be7c66c2a3f31462646681a325890003f8c140a853901d5b5f8de
 SOURCE_SUM_PRG=sha256sum
 ARCH_FORMAT=tar.gz
 SOURCE_IN_SUBDIR=true
-SOURCE_FILENAME=
+SOURCE_FILENAME=wekan-2.56.tar.gz

--- a/manifest.json
+++ b/manifest.json
@@ -6,11 +6,11 @@
         "en": "Trello-like kanban",
         "fr": "Un kanban similaire à Trello"
     },
-    "version": "2.48~ynh1",
+    "version": "2.56~ynh1",
     "url": "https://wekan.io",
     "license": "MIT",
     "maintainer": {
-        "name": "alexAubin",
+        "name": "alexAubin ljf",
         "email": "alex.aubin@mailoo.org",
         "url": "https://github.com/alexAubin/"
     },


### PR DESCRIPTION
## Problem
- *Upgrade to wekan 2.56*
- Source origin

## Solution
- *Wekan 2.56*
- *Upload 2.56 on build.yunohost.org*

## PR Status
- [x] Code finished.
- [x] Tested with Package_check.
- [x] Fix or enhancement tested.
- [x] Upgrade from last version tested.
- [x] Can be reviewed and tested.

## Validation
---
- [ ] **Code review**
- [x] **Approval (LGTM)**  yalh76
- **CI succeeded** : 
https://ci-apps-dev.yunohost.org/jenkins/job/wekan_ynh%20(ljf)/2/console