### PR TITLE
Also add mongo-tools

### DIFF
--- a/scripts/_common.sh
+++ b/scripts/_common.sh
@@ -5,7 +5,7 @@
 #=================================================
 
 # dependencies used by the app
-pkg_dependencies="mongodb mongodb-server"
+pkg_dependencies="mongodb mongodb-server mongo-tools"
 
 #=================================================
 # PERSONAL HELPERS


### PR DESCRIPTION
This allows for `mongodump` to be available when running backup.

Otherwise, you get:

> Warning: /tmp/backup_Zx8aoj: line 52: mongodump: command not found
