### PR TITLE
[fix] propagate mongodb service name in yunohost

### DIFF
--- a/scripts/install
+++ b/scripts/install
@@ -178,7 +178,7 @@ find "$final_path" -type d -print0 | xargs -0 chmod 750
 ynh_print_info --message="Integrating service in YunoHost..."
 
 yunohost service add $app --description "Wekan daemon"
-yunohost service add mongodb --description "MongoDB daemon" --log "/var/log/mongodb/mongodb.log"
+yunohost service add $mongodb_servicename --description "MongoDB daemon" --log "/var/log/mongodb/mongodb.log"
 
 
 #=================================================

--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -108,7 +108,7 @@ if ynh_version_gt "1.07~ynh2" "${previous_version}" ; then
    ynh_remove_app_dependencies
    ynh_install_app_dependencies "mongodb mongodb-server"
    yunohost service remove mongod
-   yunohost service add mongodb --log "/var/log/mongodb/mongodb.log"
+   yunohost service add $mongodb_servicename --log "/var/log/mongodb/mongodb.log"
 fi
 
 if ynh_version_gt "2.56~ynh1" "${previous_version}" ; then


### PR DESCRIPTION
## Problem
- In Buster, the wrong MongoDB service name is advertised to YunoHost webadmin (`mongodb` instead of `mongod`)

## Solution
- Use the available `$mongodb_servicename` variable in `yunohost service add` commands.

## PR Status
- [x] Code finished.
- [ ] Tested with Package_check.
- [ ] Fix or enhancement tested.
- [ ] Upgrade from last version tested.
- [x] Can be reviewed and tested.
