### PR TITLE
Properly remove service integration in Buster

### DIFF
--- a/check_process
+++ b/check_process
@@ -21,7 +21,9 @@
 		# 4.09~ynh1
 		upgrade=1	from_commit=c2b4715e8591031f3054cedb1220e7619607bb36
 		# 4.43~ynh1
-		upgrade=1	from_commit=2cf63bd4d660eae4526221c1a68efede499e3ee6		
+		upgrade=1	from_commit=2cf63bd4d660eae4526221c1a68efede499e3ee6
+		# 4.64~ynh1
+		upgrade=1	from_commit=32fe3a7c342e5f29d7a7534125151723f916de46
 		backup_restore=1
 		multi_instance=1
 		# This test is no longer necessary since the version 2.7 (PR: https://github.com/YunoHost/yunohost/pull/304), you can still do it if your app could be installed with this version.
@@ -45,3 +47,5 @@ Notification=down
 		name=4.09~ynh1
 	; commit=2cf63bd4d660eae4526221c1a68efede499e3ee6
 		name=4.43~ynh1
+	; commit=32fe3a7c342e5f29d7a7534125151723f916de46
+		name=4.64~ynh1

--- a/manifest.json
+++ b/manifest.json
@@ -6,7 +6,7 @@
         "en": "Trello-like kanban",
         "fr": "Un kanban similaire à Trello"
     },
-    "version": "4.64~ynh1",
+    "version": "4.64~ynh2",
     "url": "https://wekan.io",
     "license": "MIT",
     "maintainer": [

--- a/scripts/install
+++ b/scripts/install
@@ -65,7 +65,7 @@ ynh_app_setting_set --app=$app --key=is_public --value=$is_public
 #=================================================
 # FIND AND OPEN A PORT
 #=================================================
-ynh_script_progression --message="Configuring firewall..."
+ynh_script_progression --message="Finding an available port..."
 
 # Find an available port
 port=$(ynh_find_port --port=8095)


### PR DESCRIPTION
## Problem
- Service integration remains even after the app (or MongoDB actually) is removed.

## Solution
- Use the right service name in service removal.

## PR Status
- [ ] Code finished.
- [ ] Tested with Package_check.
- [ ] Fix or enhancement tested.
- [ ] Upgrade from last version tested.
- [ ] Can be reviewed and tested.
