### PR TITLE
Remove `arm64` from supported platforms.

### DIFF
--- a/manifest.toml
+++ b/manifest.toml
@@ -18,7 +18,7 @@ code = "https://github.com/wekan/wekan"
 
 [integration]
 yunohost = ">= 11.2"
-architectures = ["arm64", "amd64"]
+architectures = ["amd64"]
 multi_instance = true
 
 ldap = true


### PR DESCRIPTION
## Problem

- Upstream removed `arm64` prebuilts so WEKAN'T install on that arch.

## Solution

- Remove from compatible archs.

## PR Status

- [ ] Code finished and ready to be reviewed/tested
- [ ] The fix/enhancement were manually tested (if applicable)

## Automatic tests

Automatic tests can be triggered on https://ci-apps-dev.yunohost.org/ *after creating the PR*, by commenting "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!". (N.B. : for this to work you need to be a member of the Yunohost-Apps organization)
