### PR TITLE
Use MongoDB repo suitable for Debian release.

### DIFF
--- a/scripts/_common.sh
+++ b/scripts/_common.sh
@@ -327,7 +327,7 @@ ynh_install_mongo() {
 	mongo_version="${mongo_version:-$YNH_MONGO_VERSION}"
 
 	ynh_print_info --message="Installing MongoDB Community Edition..."
-	ynh_install_extra_app_dependencies --repo="deb http://repo.mongodb.org/apt/debian  $(lsb_release --codename --short)/mongodb-org/$mongo_version main" --package="mongodb-org mongodb-org-server mongodb-org-tools mongodb-mongosh" --key="https://www.mongodb.org/static/pgp/server-$mongo_version.asc"
+	ynh_install_extra_app_dependencies --repo="deb http://repo.mongodb.org/apt/debian $(lsb_release --codename --short)/mongodb-org/$mongo_version main" --package="mongodb-org mongodb-org-server mongodb-org-tools mongodb-mongosh" --key="https://www.mongodb.org/static/pgp/server-$mongo_version.asc"
 	mongodb_servicename=mongod
 
 	# Make sure MongoDB is started and enabled

--- a/scripts/_common.sh
+++ b/scripts/_common.sh
@@ -327,7 +327,7 @@ ynh_install_mongo() {
 	mongo_version="${mongo_version:-$YNH_MONGO_VERSION}"
 
 	ynh_print_info --message="Installing MongoDB Community Edition..."
-	ynh_install_extra_app_dependencies --repo="deb http://repo.mongodb.org/apt/debian buster/mongodb-org/$mongo_version main" --package="mongodb-org mongodb-org-server mongodb-org-tools mongodb-mongosh" --key="https://www.mongodb.org/static/pgp/server-$mongo_version.asc"
+	ynh_install_extra_app_dependencies --repo="deb http://repo.mongodb.org/apt/debian  $(lsb_release --codename --short)/mongodb-org/$mongo_version main" --package="mongodb-org mongodb-org-server mongodb-org-tools mongodb-mongosh" --key="https://www.mongodb.org/static/pgp/server-$mongo_version.asc"
 	mongodb_servicename=mongod
 
 	# Make sure MongoDB is started and enabled


### PR DESCRIPTION
## Problem

- `bookworm` fails

## Solution

- Use different MongoDB repo.

## PR Status

- [ ] Code finished and ready to be reviewed/tested
- [ ] The fix/enhancement were manually tested (if applicable)

## Automatic tests

Automatic tests can be triggered on https://ci-apps-dev.yunohost.org/ *after creating the PR*, by commenting "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!". (N.B. : for this to work you need to be a member of the Yunohost-Apps organization)
