### PR TITLE
Update the auto-update regex to require file ending in .zip

### DIFF
--- a/manifest.toml
+++ b/manifest.toml
@@ -50,8 +50,8 @@ ram.runtime = "50M"
         arm64.sha256 = "130bc7574651caaabbfccd2fe480ee36e9e10eaed16a04e2e3fdbc9c2242c37c"
 
         autoupdate.strategy = "latest_github_release"
-        autoupdate.asset.amd64 = ".*-amd64.zip"
-        autoupdate.asset.arm64 = "wekan-\\d+\\.\\d+-arm64.zip"
+        autoupdate.asset.amd64 = "wekan-\\d+\\.\\d+-amd64.zip$"
+        autoupdate.asset.arm64 = "wekan-\\d+\\.\\d+-arm64.zip$"
 
     [resources.ports]
 


### PR DESCRIPTION


## Problem

It seems that the upstream added new release assets like "wekan-10.61-amd64.zip.sha256sum" starting in version 10.61

This broke the auto-update because the .zip and the .zip.sha256sum assets matched the regex.

## Solution



This commit fixes the problem by adding an end-of-string anchor.

I've also harmonized both regexes to use the more strict format from arm64.

## PR Status

- [x] Code finished and ready to be reviewed/tested
- [ ] The fix/enhancement were manually tested (if applicable)

## Automatic tests

Automatic tests can be triggered on https://ci-apps-dev.yunohost.org/ *after creating the PR*, by commenting "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!". (N.B. : for this to work you need to be a member of the Yunohost-Apps organization)
