### PR TITLE
Upgrade to v11.28

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Trello-like kanban
 
 [![🌐 Official app website](https://img.shields.io/badge/Official_app_website-darkgreen?style=for-the-badge)](https://wekan.github.io)
 [![App Demo](https://img.shields.io/badge/App_Demo-blue?style=for-the-badge)](https://demo.sandstorm.io/appdemo/m86q05rdvj14yvn78ghaxynqz7u2svw6rnttptxx49g1785cdv1h)
-[![Version: 11.16~ynh1](https://img.shields.io/badge/Version-11.16~ynh1-rgb(18,138,11)?style=for-the-badge)](https://ci-apps.yunohost.org/ci/apps/wekan/)
+[![Version: 11.28~ynh1](https://img.shields.io/badge/Version-11.28~ynh1-rgb(18,138,11)?style=for-the-badge)](https://ci-apps.yunohost.org/ci/apps/wekan/)
 
 <div align="center">
 <a href="https://apps.yunohost.org/app/wekan"><img height="100px" src="https://github.com/YunoHost/yunohost-artwork/raw/refs/heads/main/badges/neopossum-badges/badge_more_info_on_the_appstore.svg"/></a>

--- a/manifest.toml
+++ b/manifest.toml
@@ -5,7 +5,7 @@ name = "Wekan"
 description.en = "Trello-like kanban"
 description.fr = "Kanban similaire à Trello"
 
-version = "11.16~ynh1"
+version = "11.28~ynh1"
 
 maintainers = []
 
@@ -44,10 +44,10 @@ ram.runtime = "50M"
 [resources]
 
         [resources.sources.main]
-        amd64.url = "https://github.com/wekan/wekan/releases/download/v11.16/wekan-11.16-amd64.zip"
-        amd64.sha256 = "c78c65e024c09f37d2c3919320294fea2ae6f82d10c65be8abf61f136f9197cb"
-        arm64.url = "https://github.com/wekan/wekan/releases/download/v11.16/wekan-11.16-arm64.zip"
-        arm64.sha256 = "e54204b5bbd7894c0503106a0bd4040748c16d51f89c7819d7bb9085d074c25d"
+        amd64.url = "https://github.com/wekan/wekan/releases/download/v11.28/wekan-11.28-amd64.zip"
+        amd64.sha256 = "7a33fc3c17cc65d8173c21e43705542ad6f87814207b641c6e4bf9d25592c028"
+        arm64.url = "https://github.com/wekan/wekan/releases/download/v11.28/wekan-11.28-arm64.zip"
+        arm64.sha256 = "0d2310f861455754e02f39f3b27c75c4ee53d9e55da29e8aab69aa4cb3ae725d"
 
         autoupdate.strategy = "latest_github_release"
         autoupdate.asset.amd64 = "wekan-\\d+\\.\\d+-amd64.zip$"


### PR DESCRIPTION
Upgrade sources
- `main` v11.28: https://github.com/wekan/wekan/releases/tag/v11.28